### PR TITLE
Return parent as AttributeCachingPath if it is not one, or return null

### DIFF
--- a/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingPath.kt
+++ b/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingPath.kt
@@ -72,6 +72,24 @@ internal class AttributeCachingPath(
 
     override fun getFileSystem(): FileSystem = fileSystem
 
+    override fun getRoot(): Path? = if (delegate.root != null && delegate.root !is AttributeCachingPath) {
+        AttributeCachingPath(fileSystem, delegate.root)
+    } else {
+        delegate.root
+    }
+
+    override fun getFileName(): Path? = if (delegate.fileName != null && delegate.fileName !is AttributeCachingPath) {
+        AttributeCachingPath(fileSystem, delegate.fileName)
+    } else {
+        delegate.fileName
+    }
+
+    override fun getParent(): Path? = if (delegate.parent != null && delegate.parent !is AttributeCachingPath) {
+        AttributeCachingPath(fileSystem, delegate.parent)
+    } else {
+        delegate.parent
+    }
+
     override fun resolve(other: Path): Path {
         // Make sure if other is a AttributeCachingPath that we pass along other's
         // delegate rather than other itself.

--- a/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemTests.kt
+++ b/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemTests.kt
@@ -1,5 +1,6 @@
 package com.pkware.filesystem.attributecaching
 
+import com.google.common.jimfs.Jimfs
 import com.google.common.truth.ComparableSubject
 import com.google.common.truth.Truth.assertThat
 import org.apache.commons.io.IOUtils
@@ -84,7 +85,22 @@ class AttributeCachingFileSystemTests {
     }
 
     @Test
-    fun `create java io tmpdir file with default filesystem wrapped by file attribute caching filesystem`() {
+    fun `create java io tmpdir directory with jimfs does not throw a ProviderMismatchException`() {
+        val filesystem = AttributeCachingFileSystem.wrapping(Jimfs.newFileSystem())
+        assertDoesNotThrow {
+            val javaTmpPath = filesystem.getPath(System.getProperty("java.io.tmpdir"))
+
+            if (!Files.exists(javaTmpPath)) {
+                Files.createDirectories(javaTmpPath)
+            }
+            assertThat(Files.exists(javaTmpPath)).isTrue()
+            Files.deleteIfExists(javaTmpPath)
+        }
+        filesystem.close()
+    }
+
+    @Test
+    fun `create java io tmpdir file with default filesystem does not throw a NullPointerException`() {
         AttributeCachingFileSystem.wrapping(FileSystems.getDefault()).use {
             assertDoesNotThrow {
                 val javaTmpPath = it.getPath(System.getProperty("java.io.tmpdir"))


### PR DESCRIPTION
Return root as AttributeCachingPath if it is not one, or return null

Return fileName as AttributeCachingPath if it is not one, or return null

Add test to demonstrate getParent functionality works from specifically failing unpacker test