### PR TITLE
Release 1.0.3 - Make the file attribute cache on demand and remove all init logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.0.3]
+- Make the AttributeCachingPath on demand and remove all init logic.
+- Add individual public properties to check if a given attribute has been cached.
+- AttributeCachingPath copyCachedAttributesTo() only copies attributes if they were previously cached or we force copy
+attributes via forceCopyAttributes = true.
+
 ## [1.0.2]
 - Gradle, Kotlin, and other dependency versions updated.
 - Add caching of AclFileAttributeView owner and aclEntries attributes as properties of AttributeCachingPath.
@@ -16,6 +22,7 @@ Fixed issues with AttributeCachingPath not being used to wrap parent, root, and 
 Initial work for the file attribute caching filesystem using cached attribute fields that do not expire.
 
 [Unreleased]: https://github.com/pkware/attributeCachingFileSystem/tree/main
+[1.0.3]: https://github.com/pkware/attributeCachingFileSystem/tree/1.0.3
 [1.0.2]: https://github.com/pkware/attributeCachingFileSystem/tree/1.0.2
 [1.0.1]: https://github.com/pkware/attributeCachingFileSystem/tree/1.0.1
 [1.0.0]: https://github.com/pkware/attributeCachingFileSystem/tree/1.0.0

--- a/detekt.yml
+++ b/detekt.yml
@@ -144,8 +144,7 @@ style:
       - 'org.junit.BeforeClass'
       - 'org.junit.After'
       - 'org.junit.AfterClass'
-      - 'org.junit.jupiter.api.Assertions'
-    forbiddenPatterns: '(?:junit\.framework|org\.junit\.jupiter\.api\.Assertions)\.(?!assertThrows).+'
+    forbiddenPatterns: '(?:junit\.framework|org\.junit\.jupiter\.api\.Assertions)\.assertThrows.+'
   ForbiddenComment:
     comments:
       - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'

--- a/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystem.kt
+++ b/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystem.kt
@@ -28,7 +28,7 @@ public class AttributeCachingFileSystem(
 
     override fun getPath(first: String, vararg more: String?): Path {
         val delegate = super.getPath(first, *more)
-        return AttributeCachingPath(this, delegate, true)
+        return AttributeCachingPath(this, delegate)
     }
 
     /**
@@ -39,7 +39,7 @@ public class AttributeCachingFileSystem(
      * @return A [Path] that now has [AttributeCachingPath] properties, or the original [path] object.
      */
     public fun convertToCachingPath(path: Path): Path = if (path !is AttributeCachingPath) {
-        AttributeCachingPath(this, path, true)
+        AttributeCachingPath(this, path)
     } else {
         path
     }

--- a/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemProvider.kt
+++ b/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemProvider.kt
@@ -119,7 +119,7 @@ internal class AttributeCachingFileSystemProvider : FileSystemProvider() {
                 it != StandardCopyOption.COPY_ATTRIBUTES
             }.toTypedArray()
 
-            source.copyCachedAttributesTo(target)
+            source.copyCachedAttributesTo(target, true)
             Files.copy(actualSourcePath, actualTargetPath, *newOptions)
         } else {
             // If the StandardCopyOption.COPY_ATTRIBUTES option is not selected, there is no need to cache the
@@ -159,7 +159,7 @@ internal class AttributeCachingFileSystemProvider : FileSystemProvider() {
                 it != StandardCopyOption.COPY_ATTRIBUTES
             }.toTypedArray()
 
-            source.copyCachedAttributesTo(target)
+            source.copyCachedAttributesTo(target, true)
             Files.move(actualSourcePath, actualTargetPath, *newOptions)
         } else {
             // If the StandardCopyOption.COPY_ATTRIBUTES option is not selected, there is no need to cache the
@@ -344,7 +344,7 @@ internal class AttributeCachingFileSystemProvider : FileSystemProvider() {
      * @param path The [Path] to set the given [attribute] on. It must be a [AttributeCachingPath] otherwise an
      * [IOException] will be thrown.
      * @param attribute The attribute name to set and associate with the [path].
-     * @param value The value of the [attribute] to set.
+     * @param value The value of the [attribute] to set, can be `null`.
      * @param options The [LinkOption]s indicating how symbolic links are handled.
      * @throws IOException If an IO error occurs.
      * @throws UnsupportedOperationException If the attribute view for the given [attribute] name is not available.
@@ -362,9 +362,6 @@ internal class AttributeCachingFileSystemProvider : FileSystemProvider() {
             return
         }
 
-        val delegatePath = path.delegate
-        val delegateProvider = delegatePath.fileSystem.provider()
-
         // Then set our cache
         // Need to make sure that we only supply class names to path.setAttributeByName
         // cannot set single attribute in the cache
@@ -377,11 +374,11 @@ internal class AttributeCachingFileSystemProvider : FileSystemProvider() {
 
         // Even if we have a single attribute only we should get the entire attribute view class for that single
         // attribute to properly set the cache.
-        val fileAttributeView: FileAttributeView? = delegateProvider.getFileAttributeView(
-            delegatePath,
+        val fileAttributeView: FileAttributeView? = provider.getFileAttributeView(
+            path.delegate,
             getAttributeViewJavaClassType(attributeCacheKey),
         )
-        path.setAttributeByName(attributeCacheKey, fileAttributeView)
+        path.setAttributeByNameUsingView(attributeCacheKey, fileAttributeView)
     }
 
     /**

--- a/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/LazyAttribute.kt
+++ b/file-attribute-caching/src/main/kotlin/com/pkware/filesystem/attributecaching/LazyAttribute.kt
@@ -1,20 +1,58 @@
 package com.pkware.filesystem.attributecaching
 
-import kotlin.reflect.KProperty
-
 /**
- * Stores a mutable attribute that is lazily calculated via [initializer] whenever the value is `null` and accessed.
+ * Stores a mutable attribute [value] that is lazily calculated via [initializer] whenever the value is `null` and
+ * accessed.
+ *
+ * Can check the initialization/assignment status of the attribute via [assigned].
+ *
  */
 internal class LazyAttribute<T>(private val initializer: () -> T?) {
 
-    private var value: T? = null
+    /**
+     * Shows whether the [value] has been assigned. `true` for initialized/assigned, default is `false`.
+     *
+     * If a value is [assigned] that means the value has been assigned via its setter or the getter has triggered an
+     * invocation of the [initializer].
+     */
+    var assigned: Boolean = false
+        private set
 
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): T? {
-        if (value == null) value = initializer()
-        return value
-    }
+    /**
+     * The mutable attribute to store. If [assigned] is false the [initializer] function is called to set the
+     * attribute.
+     */
+    var value: T? = null
+        get() {
+            if (assigned) return field
 
-    operator fun setValue(thisRef: Any?, property: KProperty<*>, newValue: T?) {
-        value = newValue
+            field = initializer()
+            assigned = true
+
+            return field
+        }
+        set(value) {
+            field = value
+            assigned = true
+        }
+
+    /**
+     * Copies the [value] of [other] into this [LazyAttribute] instance's [value] if [other] has a value assigned or
+     * [forceInitialization] is `true`.
+     *
+     * If [forceInitialization] is `true` this forces [other] to call its [initializer] function if its own [value]
+     * is not [assigned].
+     *
+     * @param other The other [LazyAttribute] to copy.
+     * @param forceInitialization Forces a copy of [other]'s value/initialization when `true`, otherwise only copies
+     * values that had already been assigned
+     */
+    fun copyValue(other: LazyAttribute<T>, forceInitialization: Boolean = false) {
+        value = if (forceInitialization || other.assigned) {
+            other.value
+        } else {
+            null
+        }
+        assigned = other.assigned
     }
 }

--- a/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemTests.kt
+++ b/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingFileSystemTests.kt
@@ -1,8 +1,15 @@
 package com.pkware.filesystem.attributecaching
 
+import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import com.google.common.truth.ComparableSubject
 import com.google.common.truth.Truth.assertThat
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.CacheableAttribute.ACL_ENTRIES
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.CacheableAttribute.ACL_OWNER
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.CacheableAttribute.BASIC
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.CacheableAttribute.DOS
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.CacheableAttribute.POSIX
+import com.pkware.filesystem.attributecaching.AttributeCachingPathSubject.Companion.assertThat
 import org.apache.commons.io.IOUtils
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -10,6 +17,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -41,6 +49,7 @@ import java.util.stream.Stream
 import kotlin.concurrent.thread
 import kotlin.io.path.div
 import kotlin.io.path.exists
+import kotlin.io.path.getLastModifiedTime
 
 class AttributeCachingFileSystemTests {
 
@@ -77,7 +86,7 @@ class AttributeCachingFileSystemTests {
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
-    fun `cache gets initialized only after file exists and getPath is called`(fileSystem: FileSystem) {
+    fun `attributes are cached on demand when using getPath`(fileSystem: FileSystem) {
         val tempDirPath = fileSystem.getPath("temp")
         Files.createDirectory(tempDirPath)
         var testPath = fileSystem.getPath("$tempDirPath${fileSystem.separator}testfile.txt")
@@ -91,17 +100,18 @@ class AttributeCachingFileSystemTests {
             testPath = it.getPath("$tempDirPath${it.separator}testfile.txt")
             assertThat(testPath).isInstanceOf(AttributeCachingPath::class.java)
             val cachingPath = testPath as AttributeCachingPath
-            assertThat(cachingPath.isCachedInitialized()).isTrue()
+            assertThat(cachingPath).hasEmptyCache()
 
             // now read attributes from caching path and verify they dont change
             val attributesMap = Files.readAttributes(cachingPath, "*")
             assertThat(attributesMap).isNotEmpty()
+            assertThat(cachingPath).caches(BASIC)
         }
     }
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
-    fun `cache gets initialized only after file exists and convertToCachingPath is called`(fileSystem: FileSystem) {
+    fun `attributes are cached on demand when using convertToCachingPath`(fileSystem: FileSystem) {
         val tempDirPath = fileSystem.getPath("temp")
         Files.createDirectory(tempDirPath)
         val testPath = fileSystem.getPath("$tempDirPath${fileSystem.separator}testfile.txt")
@@ -114,11 +124,12 @@ class AttributeCachingFileSystemTests {
             var cachingPath = it.convertToCachingPath(testPath)
             assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
             cachingPath = cachingPath as AttributeCachingPath
-            assertThat(cachingPath.isCachedInitialized()).isTrue()
+            assertThat(cachingPath).hasEmptyCache()
 
             // now read attributes from caching path and verify they are populated
             val attributesMap = Files.readAttributes(cachingPath, "*")
             assertThat(attributesMap).isNotEmpty()
+            assertThat(cachingPath).caches(BASIC)
         }
     }
 
@@ -195,31 +206,68 @@ class AttributeCachingFileSystemTests {
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
-    fun `normalize returns a cachingPath and copies attributes`(fileSystem: FileSystem) =
-        AttributeCachingFileSystem.wrapping(fileSystem).use {
-            val tempParentDirPath = it.getPath("temp")
-            val tempDirPath = it.getPath("temp${it.separator}test")
-            Files.createDirectory(tempParentDirPath)
-            Files.createDirectory(tempDirPath)
-            val cachingPath = it.getPath(
-                "temp${it.separator}.${it.separator}.${it.separator}test${it.separator}test.txt",
-            )
-            Files.createFile(cachingPath)
-            Files.newOutputStream(cachingPath).use { outputStream ->
-                outputStream.write("hello".toByteArray(Charsets.UTF_8))
-            }
-
-            Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
-
-            val normalizedPath = cachingPath.normalize()
-            assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat(normalizedPath).isInstanceOf(AttributeCachingPath::class.java)
-
-            // now read attributes from absolutePath path
-            val attributesMap = Files.readAttributes(normalizedPath, "*")
-
-            assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    fun `normalize returns a cachingPath and copies attributes if they were previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val tempParentDirPath = it.getPath("temp")
+        val tempDirPath = it.getPath("temp${it.separator}test")
+        Files.createDirectory(tempParentDirPath)
+        Files.createDirectory(tempDirPath)
+        val cachingPath = it.getPath(
+            "temp${it.separator}.${it.separator}.${it.separator}test${it.separator}test.txt",
+        )
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
         }
+
+        // cache basic attributes with setAttribute lastModifiedTime
+        Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).onlyCaches(BASIC)
+
+        val normalizedPath = cachingPath.normalize()
+
+        assertThat(normalizedPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(normalizedPath as AttributeCachingPath).onlyCaches(BASIC)
+
+        // write stuff to realPath to force lastModifiedTime update
+        Files.newOutputStream(normalizedPath).use { outputStream ->
+            outputStream.write("rewrite".toByteArray(Charsets.UTF_8))
+        }
+
+        // now read attributes from absolutePath path
+        val attributesMap = Files.readAttributes(normalizedPath, "*")
+
+        assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allFileSystems")
+    fun `normalize returns a cachingPath and does not copy attributes if they were not previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val tempParentDirPath = it.getPath("temp")
+        val tempDirPath = it.getPath("temp${it.separator}test")
+        Files.createDirectory(tempParentDirPath)
+        Files.createDirectory(tempDirPath)
+        val cachingPath = it.getPath(
+            "temp${it.separator}.${it.separator}.${it.separator}test${it.separator}test.txt",
+        )
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
+        }
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
+
+        val normalizedPath = cachingPath.normalize()
+
+        assertThat(normalizedPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(normalizedPath as AttributeCachingPath).hasEmptyCache()
+    }
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
@@ -282,47 +330,109 @@ class AttributeCachingFileSystemTests {
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
-    fun `toAbsolutePath returns a cachingPath and copies attributes`(fileSystem: FileSystem) =
-        AttributeCachingFileSystem.wrapping(fileSystem).use {
-            val cachingPath = it.getPath("test.txt")
-            Files.createFile(cachingPath)
-            Files.newOutputStream(cachingPath).use { outputStream ->
-                outputStream.write("hello".toByteArray(Charsets.UTF_8))
-            }
-
-            Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
-
-            val absolutePath = cachingPath.toAbsolutePath()
-            assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat(absolutePath).isInstanceOf(AttributeCachingPath::class.java)
-
-            // now read attributes from absolutePath path
-            val attributesMap = Files.readAttributes(absolutePath, "*")
-
-            assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    fun `toAbsolutePath returns a cachingPath and copies attributes if they were previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val cachingPath = it.getPath("test.txt")
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
         }
+
+        // cache basic attributes with setAttribute lastModifiedTime
+        Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).onlyCaches(BASIC)
+
+        val absolutePath = cachingPath.toAbsolutePath()
+
+        assertThat(absolutePath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(absolutePath as AttributeCachingPath).onlyCaches(BASIC)
+
+        // write stuff to realPath to force lastModifiedTime update
+        Files.newOutputStream(absolutePath).use { outputStream ->
+            outputStream.write("rewrite".toByteArray(Charsets.UTF_8))
+        }
+
+        // now read attributes from absolutePath path to confirm they were saved
+        val attributesMap = Files.readAttributes(absolutePath, "*")
+
+        assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    }
 
     @ParameterizedTest
     @MethodSource("allFileSystems")
-    fun `toRealPath returns a cachingPath and copies attributes`(fileSystem: FileSystem) =
-        AttributeCachingFileSystem.wrapping(fileSystem).use {
-            val cachingPath = it.getPath("test.txt")
-            Files.createFile(cachingPath)
-            Files.newOutputStream(cachingPath).use { outputStream ->
-                outputStream.write("hello".toByteArray(Charsets.UTF_8))
-            }
-
-            Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
-
-            val realPath = cachingPath.toRealPath()
-            assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat(realPath).isInstanceOf(AttributeCachingPath::class.java)
-
-            // now read attributes from absolutePath path
-            val attributesMap = Files.readAttributes(realPath, "*")
-
-            assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    fun `toAbsolutePath returns a cachingPath and does not copy attributes if they were not previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val cachingPath = it.getPath("test.txt")
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
         }
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
+
+        val absolutePath = cachingPath.toAbsolutePath()
+
+        assertThat(absolutePath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(absolutePath as AttributeCachingPath).hasEmptyCache()
+    }
+
+    @ParameterizedTest
+    @MethodSource("allFileSystems")
+    fun `toRealPath returns a cachingPath and copies attributes if they were previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val cachingPath = it.getPath("test.txt")
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
+        }
+
+        // cache basic attributes with setAttribute lastModifiedTime
+        Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).onlyCaches(BASIC)
+
+        val realPath = cachingPath.toRealPath()
+
+        assertThat(realPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(realPath as AttributeCachingPath).onlyCaches(BASIC)
+
+        // write stuff to realPath to force lastModifiedTime update
+        Files.newOutputStream(realPath).use { outputStream ->
+            outputStream.write("rewrite".toByteArray(Charsets.UTF_8))
+        }
+
+        // now read attributes from realPath path to confirm they were saved
+        val attributesMap = Files.readAttributes(realPath, "*")
+
+        assertThat(attributesMap["lastModifiedTime"]).isEqualTo(testDateFileTime)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allFileSystems")
+    fun `toRealPath returns a cachingPath and does not copy attributes if they were not previously cached`(
+        fileSystem: FileSystem,
+    ) = AttributeCachingFileSystem.wrapping(fileSystem).use {
+        val cachingPath = it.getPath("test.txt")
+        Files.createFile(cachingPath)
+        Files.newOutputStream(cachingPath).use { outputStream ->
+            outputStream.write("hello".toByteArray(Charsets.UTF_8))
+        }
+
+        assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
+
+        val realPath = cachingPath.toRealPath()
+
+        assertThat(realPath).isInstanceOf(AttributeCachingPath::class.java)
+        assertThat(realPath as AttributeCachingPath).hasEmptyCache()
+    }
 
     @ParameterizedTest
     @MethodSource("allTypes")
@@ -387,7 +497,7 @@ class AttributeCachingFileSystemTests {
         val testDir = javaTmpDir / "TEST-POSIX-$uniqueID"
         Files.createDirectories(testDir)
 
-        var cachingPath = testDir / "testfile-$uniqueID.txt"
+        val cachingPath = testDir / "testfile-$uniqueID.txt"
 
         Files.createFile(cachingPath)
         Files.newOutputStream(cachingPath).use { outputStream ->
@@ -395,16 +505,14 @@ class AttributeCachingFileSystemTests {
         }
 
         assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-        assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isFalse()
-        // Force cachingPath initialization after the file is created with getPath on the path's string representation.
-        // This test requires that the cache of the file under test be initialized.
-        cachingPath = it.getPath(cachingPath.toString())
-        assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isTrue()
+
+        assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
 
         try {
             // Test with original file owner and group on default filesystem because it's a large amount of work to
             // create our own test user and group there.
             val originalAttributeMapOwner = Files.readAttributes(cachingPath, "posix:owner")
+
             val owner = originalAttributeMapOwner["owner"] as? UserPrincipal
             val originalAttributeMapGroup = Files.readAttributes(cachingPath, "posix:group")
             val group = originalAttributeMapGroup["group"] as? GroupPrincipal
@@ -419,6 +527,7 @@ class AttributeCachingFileSystemTests {
             Files.setAttribute(cachingPath, "posix:owner", owner)
             Files.setAttribute(cachingPath, "posix:group", group)
             Files.setAttribute(cachingPath, "posix:permissions", permissions)
+
             val attributesMap = Files.readAttributes(cachingPath, "posix:*")
 
             assertThat(attributesMap.size).isEqualTo(12)
@@ -447,7 +556,7 @@ class AttributeCachingFileSystemTests {
             val javaTmpDir = it.getPath(System.getProperty("java.io.tmpdir"))
             val testDir = javaTmpDir / "TEST-ACL-$uniqueID"
             Files.createDirectories(testDir)
-            var cachingPath = testDir / "testfile-$uniqueID.txt"
+            val cachingPath = testDir / "testfile-$uniqueID.txt"
 
             Files.createFile(cachingPath)
             Files.newOutputStream(cachingPath).use { outputStream ->
@@ -455,16 +564,14 @@ class AttributeCachingFileSystemTests {
             }
 
             assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isFalse()
-            // Force cachingPath initialization after the file is created with getPath on the path's string representation.
-            // This test requires that the cache of the file under test be initialized.
-            cachingPath = it.getPath(cachingPath.toString())
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isTrue()
+
+            assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
 
             try {
                 // Test with original file owner on default filesystem because it's a large amount of work to create our
                 // own test user there.
                 val originalAttributesMap = Files.readAttributes(cachingPath, "acl:owner")
+
                 val owner = originalAttributesMap["owner"] as? UserPrincipal
                 val acl = AclEntry.newBuilder()
                     .setType(AclEntryType.ALLOW)
@@ -487,6 +594,7 @@ class AttributeCachingFileSystemTests {
 
                 Files.setAttribute(cachingPath, "acl:owner", owner)
                 Files.setAttribute(cachingPath, "acl:acl", aclEntries)
+
                 val attributesMap = Files.readAttributes(cachingPath, "acl:*")
 
                 // verify that attribute is "right" type returned from the provider
@@ -512,7 +620,7 @@ class AttributeCachingFileSystemTests {
             val javaTmpDir = it.getPath(System.getProperty("java.io.tmpdir"))
             val testDir = javaTmpDir / "TEST-ACL-$uniqueID"
             Files.createDirectories(testDir)
-            var cachingPath = testDir / "testfile-$uniqueID.txt"
+            val cachingPath = testDir / "testfile-$uniqueID.txt"
 
             Files.createFile(cachingPath)
             Files.newOutputStream(cachingPath).use { outputStream ->
@@ -520,17 +628,14 @@ class AttributeCachingFileSystemTests {
             }
 
             assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isFalse()
-            // Force cachingPath initialization after the file is created with getPath on the path's string representation.
-            // This test requires that the cache of the file under test be initialized.
-            cachingPath = it.getPath(cachingPath.toString())
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isTrue()
+            assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
 
             try {
                 // Test with original file owner on default filesystem because it's a large amount of work to create our
                 // own test user there.
 
                 val originalAttributeMap = Files.readAttributes(cachingPath, "acl:*")
+
                 val originalOwner = originalAttributeMap["owner"] as? UserPrincipal
 
                 @Suppress("UNCHECKED_CAST")
@@ -589,7 +694,7 @@ class AttributeCachingFileSystemTests {
             val javaTmpDir = it.getPath(System.getProperty("java.io.tmpdir"))
             val testDir = javaTmpDir / "TEST-ACL-$uniqueID"
             Files.createDirectories(testDir)
-            var cachingPath = testDir / "testfile-$uniqueID.txt"
+            val cachingPath = testDir / "testfile-$uniqueID.txt"
 
             Files.createFile(cachingPath)
             Files.newOutputStream(cachingPath).use { outputStream ->
@@ -597,11 +702,8 @@ class AttributeCachingFileSystemTests {
             }
 
             assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isFalse()
-            // Force cachingPath initialization after the file is created with getPath on the path's string representation.
-            // This test requires that the cache of the file under test be initialized.
-            cachingPath = it.getPath(cachingPath.toString())
-            assertThat((cachingPath as AttributeCachingPath).isCachedInitialized()).isTrue()
+
+            assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
 
             try {
                 // Test with original file owner on default filesystem because it's a large amount of work to create our
@@ -610,6 +712,8 @@ class AttributeCachingFileSystemTests {
                 val originalAttributeView = Files.getFileAttributeView(cachingPath, AclFileAttributeView::class.java)
                 val originalOwner = originalAttributeView.owner
                 val originalAclEntries = originalAttributeView.acl
+
+                assertThat(cachingPath).hasEmptyCache()
 
                 // simulate concurrent modification on default filesystem
                 val concurrentPath = defaultFileSystem.getPath(
@@ -643,6 +747,7 @@ class AttributeCachingFileSystemTests {
                 assertThat(originalOwner).isEqualTo(newOwner)
                 // acl entries do change because we modified the acl entries in the concurrent file path
                 assertThat(originalAclEntries).doesNotContain(newAclEntries)
+                assertThat(cachingPath).hasEmptyCache()
             } finally {
                 Files.deleteIfExists(cachingPath)
                 Files.deleteIfExists(testDir)
@@ -741,38 +846,72 @@ class AttributeCachingFileSystemTests {
     fun `copy file from source to target`(
         option: CopyOption,
         fileSystem: () -> FileSystem,
-    ) = AttributeCachingFileSystem.wrapping(fileSystem()).use {
-        // get filesystem attribute caching path
-        val cachingPath = it.getPath("testfile.txt")
-        Files.createFile(cachingPath)
-        Files.newOutputStream(cachingPath).use { outputStream ->
-            outputStream.write("hello".toByteArray(Charsets.UTF_8))
+    ) {
+        val testFileSystem = fileSystem()
+        AttributeCachingFileSystem.wrapping(testFileSystem).use {
+            // get filesystem attribute caching path
+            val cachingPath = it.getPath("testfile.txt")
+            Files.createFile(cachingPath)
+            Files.newOutputStream(cachingPath).use { outputStream ->
+                outputStream.write("hello".toByteArray(Charsets.UTF_8))
+            }
+
+            assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+
+            assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
+
+            Files.setAttribute(cachingPath, "creationTime", testDateFileTime)
+            Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
+            Files.setAttribute(cachingPath, "lastAccessTime", testDateFileTime)
+
+            assertThat(cachingPath).onlyCaches(BASIC)
+
+            val destinationCachingPath = it.getPath("testfile2.txt")
+
+            assertThat(destinationCachingPath).isInstanceOf(AttributeCachingPath::class.java)
+
+            assertThat(destinationCachingPath as AttributeCachingPath).hasEmptyCache()
+
+            assertThat(destinationCachingPath.exists()).isEqualTo(false)
+
+            Files.copy(cachingPath, destinationCachingPath, option)
+
+            assertThat(cachingPath.exists()).isEqualTo(true)
+            assertThat(destinationCachingPath.exists()).isEqualTo(true)
+
+            if (option == StandardCopyOption.COPY_ATTRIBUTES) {
+                when (getOsString(testFileSystem)) {
+                    "windows" -> assertThat(destinationCachingPath).onlyCaches(BASIC, DOS, ACL_OWNER, ACL_ENTRIES)
+                    "posix" -> assertThat(destinationCachingPath).onlyCaches(BASIC, POSIX)
+                    else -> fail("Unexpected Jimfs Operating System in use by this test.")
+                }
+            } else {
+                assertThat(destinationCachingPath).hasEmptyCache()
+            }
+
+            Files.newInputStream(destinationCachingPath).use { inputStream ->
+                val bytes = IOUtils.toByteArray(inputStream)
+                assertThat(String(bytes, Charsets.UTF_8)).isEqualTo("hello")
+            }
+
+            val basicFileAttributes = Files.readAttributes(destinationCachingPath, "*")
+            val creationTime = basicFileAttributes["creationTime"] as FileTime
+            assertThat(creationTime).followedFlagRulesComparedTo(option, testDateFileTime)
+            val lastModifiedTime = basicFileAttributes["lastModifiedTime"] as FileTime
+            assertThat(lastModifiedTime).followedFlagRulesComparedTo(option, testDateFileTime)
+            val lastAccessTime = basicFileAttributes["lastAccessTime"] as FileTime
+            assertThat(lastAccessTime).followedFlagRulesComparedTo(option, testDateFileTime)
+
+            if (option == StandardCopyOption.COPY_ATTRIBUTES) {
+                when (getOsString(testFileSystem)) {
+                    "windows" -> assertThat(destinationCachingPath).onlyCaches(BASIC, DOS, ACL_OWNER, ACL_ENTRIES)
+                    "posix" -> assertThat(destinationCachingPath).onlyCaches(BASIC, POSIX)
+                    else -> fail("Unexpected Jimfs Operating System in use by this test.")
+                }
+            } else {
+                assertThat(destinationCachingPath).onlyCaches(BASIC)
+            }
         }
-        Files.setAttribute(cachingPath, "creationTime", testDateFileTime)
-        Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
-        Files.setAttribute(cachingPath, "lastAccessTime", testDateFileTime)
-
-        val destinationCachingPath = it.getPath("testfile2.txt")
-
-        assertThat(destinationCachingPath.exists()).isEqualTo(false)
-
-        Files.copy(cachingPath, destinationCachingPath, option)
-
-        assertThat(cachingPath.exists()).isEqualTo(true)
-        assertThat(destinationCachingPath.exists()).isEqualTo(true)
-
-        Files.newInputStream(destinationCachingPath).use { inputStream ->
-            val bytes = IOUtils.toByteArray(inputStream)
-            assertThat(String(bytes, Charsets.UTF_8)).isEqualTo("hello")
-        }
-
-        val basicFileAttributes = Files.readAttributes(destinationCachingPath, "*")
-        val creationTime = basicFileAttributes["creationTime"] as FileTime
-        assertThat(creationTime).followedFlagRulesComparedTo(option, testDateFileTime)
-        val lastModifiedTime = basicFileAttributes["lastModifiedTime"] as FileTime
-        assertThat(lastModifiedTime).followedFlagRulesComparedTo(option, testDateFileTime)
-        val lastAccessTime = basicFileAttributes["lastAccessTime"] as FileTime
-        assertThat(lastAccessTime).followedFlagRulesComparedTo(option, testDateFileTime)
     }
 
     @ParameterizedTest
@@ -780,38 +919,70 @@ class AttributeCachingFileSystemTests {
     fun `move file from source to target`(
         option: CopyOption,
         fileSystem: () -> FileSystem,
-    ) = AttributeCachingFileSystem.wrapping(fileSystem()).use {
-        // get filesystem attribute caching path
-        val cachingPath = it.getPath("testfile.txt")
-        Files.createFile(cachingPath)
-        Files.newOutputStream(cachingPath).use { outputStream ->
-            outputStream.write("hello".toByteArray(Charsets.UTF_8))
+    ) {
+        val testFileSystem = fileSystem()
+        AttributeCachingFileSystem.wrapping(testFileSystem).use {
+            // get filesystem attribute caching path
+            val cachingPath = it.getPath("testfile.txt")
+            Files.createFile(cachingPath)
+            Files.newOutputStream(cachingPath).use { outputStream ->
+                outputStream.write("hello".toByteArray(Charsets.UTF_8))
+            }
+
+            assertThat(cachingPath).isInstanceOf(AttributeCachingPath::class.java)
+
+            assertThat(cachingPath as AttributeCachingPath).hasEmptyCache()
+
+            Files.setAttribute(cachingPath, "creationTime", testDateFileTime)
+            Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
+            Files.setAttribute(cachingPath, "lastAccessTime", testDateFileTime)
+
+            assertThat(cachingPath).onlyCaches(BASIC)
+
+            // ensure temp directory exists
+            Files.createDirectory(it.getPath("temp"))
+            val destinationCachingPath = it.getPath("temp", "testfile2.txt")
+
+            assertThat(destinationCachingPath as AttributeCachingPath).hasEmptyCache()
+
+            assertThat(destinationCachingPath.exists()).isEqualTo(false)
+
+            Files.move(cachingPath, destinationCachingPath, option)
+
+            if (option == StandardCopyOption.COPY_ATTRIBUTES) {
+                when (getOsString(testFileSystem)) {
+                    "windows" -> assertThat(destinationCachingPath).onlyCaches(BASIC, DOS, ACL_OWNER, ACL_ENTRIES)
+                    "posix" -> assertThat(destinationCachingPath).onlyCaches(BASIC, POSIX)
+                    else -> fail("Unexpected Jimfs Operating System in use by this test.")
+                }
+            } else {
+                assertThat(destinationCachingPath).hasEmptyCache()
+            }
+
+            assertThat(cachingPath.exists()).isEqualTo(false)
+
+            Files.newInputStream(destinationCachingPath).use { inputStream ->
+                val bytes = IOUtils.toByteArray(inputStream)
+                assertThat(String(bytes, Charsets.UTF_8)).isEqualTo("hello")
+            }
+            val basicFileAttributes = Files.readAttributes(destinationCachingPath, "*")
+
+            // creation and move time are preserved for a move regardless of the option flag used
+            assertThat(basicFileAttributes["creationTime"]).isEqualTo(testDateFileTime)
+            assertThat(basicFileAttributes["lastModifiedTime"]).isEqualTo(testDateFileTime)
+            val lastAccessTime = basicFileAttributes["lastAccessTime"] as FileTime
+            assertThat(lastAccessTime).followedFlagRulesComparedTo(option, testDateFileTime)
+
+            if (option == StandardCopyOption.COPY_ATTRIBUTES) {
+                when (getOsString(testFileSystem)) {
+                    "windows" -> assertThat(destinationCachingPath).onlyCaches(BASIC, DOS, ACL_OWNER, ACL_ENTRIES)
+                    "posix" -> assertThat(destinationCachingPath).onlyCaches(BASIC, POSIX)
+                    else -> fail("Unexpected Jimfs Operating System in use by this test.")
+                }
+            } else {
+                assertThat(destinationCachingPath).onlyCaches(BASIC)
+            }
         }
-        Files.setAttribute(cachingPath, "creationTime", testDateFileTime)
-        Files.setAttribute(cachingPath, "lastModifiedTime", testDateFileTime)
-        Files.setAttribute(cachingPath, "lastAccessTime", testDateFileTime)
-
-        // ensure temp directory exists
-        Files.createDirectory(it.getPath("temp"))
-        val destinationCachingPath = it.getPath("temp", "testfile2.txt")
-
-        assertThat(destinationCachingPath.exists()).isEqualTo(false)
-
-        Files.move(cachingPath, destinationCachingPath, option)
-
-        assertThat(cachingPath.exists()).isEqualTo(false)
-
-        Files.newInputStream(destinationCachingPath).use { inputStream ->
-            val bytes = IOUtils.toByteArray(inputStream)
-            assertThat(String(bytes, Charsets.UTF_8)).isEqualTo("hello")
-        }
-        val basicFileAttributes = Files.readAttributes(destinationCachingPath, "*")
-
-        // creation and move time are preserved for a move regardless of the option flag used
-        assertThat(basicFileAttributes["creationTime"]).isEqualTo(testDateFileTime)
-        assertThat(basicFileAttributes["lastModifiedTime"]).isEqualTo(testDateFileTime)
-        val lastAccessTime = basicFileAttributes["lastAccessTime"] as FileTime
-        assertThat(lastAccessTime).followedFlagRulesComparedTo(option, testDateFileTime)
     }
 
     @DisabledOnOs(OS.MAC, OS.LINUX)
@@ -844,6 +1015,52 @@ class AttributeCachingFileSystemTests {
         Files.createDirectory(it.getPath(directoryName))
         val cachingPath = it.getPath(directoryName, fileName)
         assertThat(Files.isHidden(cachingPath)).isEqualTo(expectedHidden)
+    }
+
+    @Test
+    fun `only commonly supported attribute views are transferred when copying across filesystems`() {
+        AttributeCachingFileSystem.wrapping(linuxJimfs()).use { linuxFilesystem ->
+
+            val tempPath = linuxFilesystem.getPath("toCopy.txt")
+            val linuxPath = linuxFilesystem.convertToCachingPath(tempPath) as AttributeCachingPath
+            Files.createFile(linuxPath)
+            val originalPermissions = setOf(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ)
+            Files.setAttribute(linuxPath, "posix:permissions", originalPermissions)
+            Files.setAttribute(linuxPath, "lastModifiedTime", testDateFileTime)
+            assertThat(linuxPath).caches(BASIC, POSIX)
+
+            AttributeCachingFileSystem.wrapping(windowsJimfs()).use { windowsFilesystem ->
+
+                val tempFile = windowsFilesystem.rootDirectories.first().resolve("temp.txt")
+                val windowsPath = windowsFilesystem.convertToCachingPath(tempFile) as AttributeCachingPath
+                Files.copy(linuxPath, windowsPath, StandardCopyOption.COPY_ATTRIBUTES)
+                assertThat(windowsPath).onlyCaches(BASIC)
+                assertThat(windowsPath.getLastModifiedTime()).isEqualTo(testDateFileTime)
+            }
+        }
+    }
+
+    @Test
+    fun `only commonly supported attribute views are transferred when moving across filesystems`() {
+        AttributeCachingFileSystem.wrapping(linuxJimfs()).use { linuxFilesystem ->
+
+            val tempPath = linuxFilesystem.getPath("toMove.txt")
+            val linuxPath = linuxFilesystem.convertToCachingPath(tempPath) as AttributeCachingPath
+            Files.createFile(linuxPath)
+            val originalPermissions = setOf(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ)
+            Files.setAttribute(linuxPath, "posix:permissions", originalPermissions)
+            Files.setAttribute(linuxPath, "lastModifiedTime", testDateFileTime)
+            assertThat(linuxPath).caches(BASIC, POSIX)
+
+            AttributeCachingFileSystem.wrapping(windowsJimfs()).use { windowsFileSystem ->
+
+                val tempFile = windowsFileSystem.rootDirectories.first().resolve("temp.txt")
+                val windowsPath = windowsFileSystem.convertToCachingPath(tempFile) as AttributeCachingPath
+                Files.move(linuxPath, windowsPath, StandardCopyOption.COPY_ATTRIBUTES)
+                assertThat(windowsPath).onlyCaches(BASIC)
+                assertThat(windowsPath.getLastModifiedTime()).isEqualTo(testDateFileTime)
+            }
+        }
     }
 
     companion object {
@@ -894,12 +1111,6 @@ class AttributeCachingFileSystemTests {
         )
 
         @JvmStatic
-        fun posixFileSystems(): Stream<Arguments> = Stream.of(
-            arguments(::linuxJimfs),
-            arguments(::osXJimfs),
-        )
-
-        @JvmStatic
         fun hiddenTestPathsWindows(): Stream<Arguments> = Stream.of(
             arguments("test1.txt", true),
             // blank filesystem name for a directory, directories can never be hidden
@@ -937,10 +1148,34 @@ class AttributeCachingFileSystemTests {
             arguments(StandardCopyOption.ATOMIC_MOVE, ::osXJimfs),
         )
 
+        fun linuxJimfs(): FileSystem = Jimfs.newFileSystem(
+            Configuration.unix()
+                .toBuilder()
+                .setAttributeViews("basic", "owner", "posix", "unix", "user")
+                .build(),
+        )
+
+        fun windowsJimfs(): FileSystem = Jimfs.newFileSystem(
+            Configuration.windows()
+                .toBuilder()
+                .setAttributeViews("basic", "owner", "dos", "acl", "user")
+                .build(),
+        )
+
         private fun ComparableSubject<FileTime>.followedFlagRulesComparedTo(
             options: CopyOption,
             expected: FileTime,
         ) = if (options == StandardCopyOption.COPY_ATTRIBUTES) isEqualTo(expected) else isNotEqualTo(expected)
+
+        private fun getOsString(fileSystem: FileSystem): String {
+            val supportedViews = fileSystem.supportedFileAttributeViews()
+            return when {
+                supportedViews.contains("dos") -> "windows"
+                supportedViews.contains("posix") -> "posix"
+                supportedViews.contains("acl") -> "windows"
+                else -> "none"
+            }
+        }
     }
 }
 

--- a/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingPathSubject.kt
+++ b/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/AttributeCachingPathSubject.kt
@@ -1,0 +1,82 @@
+package com.pkware.filesystem.attributecaching
+
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.Truth.assertAbout
+
+internal class AttributeCachingPathSubject internal constructor(
+    metadata: FailureMetadata,
+    private val actual: AttributeCachingPath?,
+) : Subject(metadata, actual) {
+
+    /**
+     * Asserts that the [AttributeCachingPath] is caching the given [cacheableAttributes]
+     *
+     * @param cacheableAttributes Array of arguments whose values will be verified to be assigned.
+     */
+    fun caches(vararg cacheableAttributes: CacheableAttribute) {
+        checkNotNull(actual)
+        cacheableAttributes.forEach { check(attributeName(it)).that(getValueToCheck(actual, it)).isTrue() }
+    }
+
+    /**
+     * Asserts that the [AttributeCachingPath] is not caching the given [cacheableAttributes]
+     *
+     * @param cacheableAttributes Array of arguments whose values will be verified to be unassigned.
+     */
+    fun doesNotCache(vararg cacheableAttributes: CacheableAttribute) {
+        checkNotNull(actual)
+        cacheableAttributes.forEach { check(attributeName(it)).that(getValueToCheck(actual, it)).isFalse() }
+    }
+
+    /**
+     * Asserts that the [AttributeCachingPath] has no values cached.
+     */
+    fun hasEmptyCache() = onlyCaches()
+
+    /**
+     * Asserts that only the given variables representing the underlying attributes are cached.
+     *
+     * E.g. assertThat(path).onlyCaches(basic = true) makes sure that only the basic attributes are cached.
+     */
+    fun onlyCaches(vararg cacheableAttributes: CacheableAttribute) {
+        checkNotNull(actual)
+        val toAllow = cacheableAttributes.toSet()
+        val toForbid = ALLOWED_ENTRIES.subtract(toAllow)
+
+        toAllow.forEach { check(attributeName(it)).that(getValueToCheck(actual, it)).isTrue() }
+        toForbid.forEach { check(attributeName(it)).that(getValueToCheck(actual, it)).isFalse() }
+    }
+
+    private fun attributeName(attr: CacheableAttribute): String = when (attr) {
+        CacheableAttribute.BASIC -> "cachedBasicAttributes.assigned"
+        CacheableAttribute.DOS -> "cachedDosAttributes.assigned"
+        CacheableAttribute.ACL_OWNER -> "cachedAccessControlListOwner.assigned"
+        CacheableAttribute.ACL_ENTRIES -> "cachedAccessControlListEntries.assigned"
+        CacheableAttribute.POSIX -> "cachedPosixAttributes.assigned"
+    }
+
+    private fun getValueToCheck(path: AttributeCachingPath, attr: CacheableAttribute): Boolean = when (attr) {
+        CacheableAttribute.BASIC -> path.cachedBasicAttributes.assigned
+        CacheableAttribute.DOS -> path.cachedDosAttributes.assigned
+        CacheableAttribute.ACL_OWNER -> path.cachedAccessControlListOwner.assigned
+        CacheableAttribute.ACL_ENTRIES -> path.cachedAccessControlListEntries.assigned
+        CacheableAttribute.POSIX -> path.cachedPosixAttributes.assigned
+    }
+
+    enum class CacheableAttribute {
+        BASIC,
+        DOS,
+        ACL_OWNER,
+        ACL_ENTRIES,
+        POSIX,
+    }
+
+    companion object {
+        private val ALLOWED_ENTRIES = CacheableAttribute.values().toSet()
+
+        @JvmStatic
+        fun assertThat(path: AttributeCachingPath): AttributeCachingPathSubject =
+            assertAbout(::AttributeCachingPathSubject).that(path)
+    }
+}

--- a/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/LazyAttributeTest.kt
+++ b/file-attribute-caching/src/test/kotlin/com/pkware/filesystem/attributecaching/LazyAttributeTest.kt
@@ -1,0 +1,95 @@
+package com.pkware.filesystem.attributecaching
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class LazyAttributeTest {
+
+    @Test
+    fun `initializes when value is used`() {
+        val tracker = InitializedTracker()
+        val lazyAttribute = LazyAttribute {
+            tracker.initialize()
+        }
+
+        assertThat(lazyAttribute.assigned).isFalse()
+        assertThat(tracker.calls).isEqualTo(0)
+        assertThat(lazyAttribute.value).isEqualTo(1)
+        assertThat(lazyAttribute.assigned).isTrue()
+    }
+
+    @Test
+    fun `value is only initialized once`() {
+        val tracker = InitializedTracker()
+        val lazyAttribute = LazyAttribute {
+            tracker.initialize()
+        }
+
+        assertThat(tracker.calls).isEqualTo(0)
+        assertThat(lazyAttribute.value).isEqualTo(1)
+        assertThat(lazyAttribute.value).isEqualTo(1)
+        assertThat(tracker.calls).isEqualTo(1)
+    }
+
+    @Test
+    fun `does not initialize on default copy`() {
+        val tracker = InitializedTracker()
+        val lazyAttribute = LazyAttribute {
+            tracker.initialize()
+        }
+        val lazyCopy = LazyAttribute {
+            tracker.initialize()
+        }
+
+        assertThat(tracker.calls).isEqualTo(0)
+
+        lazyCopy.copyValue(lazyAttribute)
+        assertThat(tracker.calls).isEqualTo(0)
+        assertThat(lazyCopy.assigned).isFalse()
+    }
+
+    @Test
+    fun `initializes on copy forcedInitialization`() {
+        val tracker = InitializedTracker()
+        val lazyAttribute = LazyAttribute {
+            tracker.initialize()
+        }
+        val lazyCopy = LazyAttribute {
+            tracker.initialize()
+        }
+
+        assertThat(tracker.calls).isEqualTo(0)
+
+        lazyCopy.copyValue(lazyAttribute, false)
+        assertThat(tracker.calls).isEqualTo(0)
+        assertThat(lazyCopy.assigned).isFalse()
+
+        lazyCopy.copyValue(lazyAttribute, true)
+        assertThat(tracker.calls).isEqualTo(1)
+        assertThat(lazyCopy.assigned).isTrue()
+    }
+
+    @Test
+    fun `assignment is retained when forcedInitialization is false`() {
+        val initialTracker = InitializedTracker()
+        val lazyAttribute = LazyAttribute {
+            initialTracker.initialize()
+        }
+        val lazyTracker = InitializedTracker()
+        val lazyCopy = LazyAttribute {
+            lazyTracker.initialize()
+        }
+
+        lazyAttribute.value = 999
+        assertThat(lazyAttribute.assigned).isTrue()
+        assertThat(lazyAttribute.value).isEqualTo(999)
+
+        lazyCopy.copyValue(lazyAttribute, false)
+        assertThat(lazyCopy.assigned).isTrue()
+        assertThat(lazyCopy.value).isEqualTo(999)
+    }
+}
+
+class InitializedTracker(var calls: Int = 0) {
+    fun initialize(): Int = ++calls
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 kotlin.code.style=official
 
-attributeCachingFilesystemVersion=1.0.3-SNAPSHOT
+attributeCachingFilesystemVersion=1.0.3
 
 POM_NAME=Attribute Caching Filesystem
 POM_DESCRIPTION=A File Attribute Caching Filesystem Library


### PR DESCRIPTION
Adapting @mbayerPK's work in https://github.com/pkware/AttributeCachingFileSystem/pull/11 to accommodate PR feedback from https://github.com/pkware/AttributeCachingFileSystem/pull/12